### PR TITLE
Use target URL for Gitea check details.

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/gitea/GiteaChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/gitea/GiteaChecksPublisher.java
@@ -87,7 +87,7 @@ public class GiteaChecksPublisher extends ChecksPublisher {
 
         GiteaCommitStatus commitStatus = new GiteaCommitStatus();
 
-        giteaChecksDetails.getDetailsURL().ifPresent(commitStatus::setUrl);
+        giteaChecksDetails.getDetailsURL().ifPresent(commitStatus::setTargetUrl);
 
         commitStatus.setContext(giteaChecksDetails.getContextString());
 


### PR DESCRIPTION
Jenkins uses the targetUrl property in at least JUnit plugin. This displays the targetUrl in Gitea checks.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
