### PR TITLE
Switch from deprecated `useAci` syntax to `useContainerAgent`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
 ]
-buildPlugin(configurations: configurations, useAci: true)
+buildPlugin(configurations: configurations, useContainerAgent: true)


### PR DESCRIPTION
This is an automatic pull request, that switches from the deprecated `useAci` syntax to `useContainerAgent`.

Switching to the new syntax is a drop-in replacement and requires no further work from your side.
Once you merge this PR, you address the warning currently emitted on all builds in this repository:
![](https://i.imgur.com/8uCZKKC.png)

In case of questions, please ping me, `@NotMyFault`.

Additional information:

- [Click here to read more about the deprecated syntax](https://github.com/jenkins-infra/pipeline-library/#optional-arguments)

cc @jenkinsci/gitea-checks-plugin-developers 

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.