### PR TITLE
Modernization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+# Maintain dependencies for your plugin
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: master
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.82</version>
+    <version>4.83</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>3080.vfa_b_e4a_a_39b_44</version>
-        <type>pom</type>
+        <version>3143.v347db_7c6db_6e</version>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/io/jenkins/plugins/checks/gitea/GiteaChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/gitea/GiteaChecksContext.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.checks.gitea;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Job;
 import hudson.model.Run;
 import org.apache.commons.lang3.StringUtils;
@@ -74,6 +75,7 @@ public abstract class GiteaChecksContext {
      *
      * @return the credentials
      */
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Shouldn't get null from getCredentialsId()")
     public StandardCredentials getCredentials() {
         return getGiteaAppCredentials(getCredentialsId());
     }


### PR DESCRIPTION
Following #136 , I added a few more steps in the modernization.
Unfortunately, they don't solve the `getJenkins() is null` problem, but they add a few things (spotbugs, dependabot), following the [tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/).

`20:35:07  java.lang.NullPointerException: Cannot invoke "org.jvnet.hudson.test.JenkinsRule.createProject(java.lang.Class)" because the return value of "io.jenkins.plugins.util.IntegrationTest.getJenkins()" is null
`
### Testing done

`mvn clean verify
`
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
